### PR TITLE
Add Avalonia test UI

### DIFF
--- a/Source/CSharpClient/OceanSimulation.Presentation.Avalonia/OceanSimulation.Presentation.Avalonia.csproj
+++ b/Source/CSharpClient/OceanSimulation.Presentation.Avalonia/OceanSimulation.Presentation.Avalonia.csproj
@@ -14,10 +14,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\OceanSimulation.Domain\OceanSimulation.Domain.csproj" />
+    <ProjectReference Include="..\OceanSimulation.Infrastructure\OceanSimulation.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.2" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Include="Avalonia.Diagnostics" Version="11.3.2">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>

--- a/Source/CSharpClient/OceanSimulation.Presentation.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/Source/CSharpClient/OceanSimulation.Presentation.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,130 @@
-﻿namespace OceanSimulation.Presentation.Avalonia.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Media.Imaging;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using OceanSimulation.Infrastructure.ComputeEngines;
+
+namespace OceanSimulation.Presentation.Avalonia.ViewModels;
 
 public partial class MainWindowViewModel : ViewModelBase
 {
-    public string Greeting { get; } = "Welcome to Avalonia!";
+    [ObservableProperty]
+    private string? netcdfPath;
+
+    [ObservableProperty]
+    private Bitmap? resultImage;
+
+    [ObservableProperty]
+    private string status = "Ready";
+
+    private readonly ILoggerFactory _loggerFactory;
+    private OceanDataInterface? _dataInterface;
+    private OceanStatisticalAnalysis? _analysis;
+    private NetCDFParticleInterface? _particleInterface;
+
+    public MainWindowViewModel()
+    {
+        _loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+        VisualizeCommand = new AsyncRelayCommand(GenerateVisualizationAsync);
+        VorticityCommand = new AsyncRelayCommand(GenerateVorticityAsync);
+        ParticleCommand = new AsyncRelayCommand(RunParticleAsync);
+        PollutionCommand = new AsyncRelayCommand(RunPollutionAsync);
+        EnkfCommand = new AsyncRelayCommand(RunEnkfAsync);
+    }
+
+    public IAsyncRelayCommand VisualizeCommand { get; }
+    public IAsyncRelayCommand VorticityCommand { get; }
+    public IAsyncRelayCommand ParticleCommand { get; }
+    public IAsyncRelayCommand PollutionCommand { get; }
+    public IAsyncRelayCommand EnkfCommand { get; }
+
+    private async Task EnsureInitializedAsync()
+    {
+        if (_dataInterface != null)
+            return;
+
+        var config = new Dictionary<string, object>
+        {
+            ["PythonExecutablePath"] = "python3",
+            ["PythonEngineRootPath"] = "../../../PythonEngine"
+        };
+
+        _dataInterface = new OceanDataInterface(_loggerFactory.CreateLogger<OceanDataInterface>(), config);
+        await _dataInterface.InitializeAsync();
+        _analysis = new OceanStatisticalAnalysis(_loggerFactory.CreateLogger<OceanStatisticalAnalysis>(), config);
+        await _analysis.InitializeAsync();
+        _particleInterface = new NetCDFParticleInterface(_loggerFactory.CreateLogger<NetCDFParticleInterface>(), config);
+        await _particleInterface.InitializeAsync();
+    }
+
+    private async Task GenerateVisualizationAsync()
+    {
+        if (string.IsNullOrEmpty(NetcdfPath)) return;
+        await EnsureInitializedAsync();
+        Status = "Generating visualization...";
+        var path = await _dataInterface!.GenerateVisualizationFromFileAsync(NetcdfPath);
+        if (!string.IsNullOrEmpty(path) && File.Exists(path))
+        {
+            ResultImage = new Bitmap(path);
+            Status = "Visualization complete";
+        }
+        else
+        {
+            Status = "Visualization failed";
+        }
+    }
+
+    private async Task GenerateVorticityAsync()
+    {
+        if (string.IsNullOrEmpty(NetcdfPath)) return;
+        await EnsureInitializedAsync();
+        Status = "Calculating vorticity/divergence...";
+        var path = await _analysis!.CalculateVorticityDivergenceFieldAsync(NetcdfPath);
+        if (!string.IsNullOrEmpty(path) && File.Exists(path))
+        {
+            ResultImage = new Bitmap(path);
+            Status = "Vorticity/Divergence complete";
+        }
+        else
+        {
+            Status = "Calculation failed";
+        }
+    }
+
+    private async Task RunParticleAsync()
+    {
+        if (string.IsNullOrEmpty(NetcdfPath)) return;
+        await EnsureInitializedAsync();
+        Status = "Running particle tracking...";
+        var cfg = new ParticleTrackingConfig();
+        var result = await _particleInterface!.TrackSingleParticleAsync(NetcdfPath, (0,0), cfg);
+        if (result?.Success == true)
+        {
+            var viz = await _particleInterface.CreateTrajectoryVisualizationAsync(NetcdfPath, result.Trajectory);
+            if (viz?.Success == true && File.Exists(viz.OutputPath))
+            {
+                ResultImage = new Bitmap(viz.OutputPath);
+                Status = "Particle tracking complete";
+                return;
+            }
+        }
+        Status = "Particle tracking failed";
+    }
+
+    private Task RunPollutionAsync()
+    {
+        Status = "Pollution diffusion not implemented";
+        return Task.CompletedTask;
+    }
+
+    private Task RunEnkfAsync()
+    {
+        Status = "EnKF prediction not implemented";
+        return Task.CompletedTask;
+    }
 }

--- a/Source/CSharpClient/OceanSimulation.Presentation.Avalonia/Views/MainWindow.axaml
+++ b/Source/CSharpClient/OceanSimulation.Presentation.Avalonia/Views/MainWindow.axaml
@@ -1,20 +1,30 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:OceanSimulation.Presentation.Avalonia.ViewModels"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="OceanSimulation.Presentation.Avalonia.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
+        Width="800" Height="600"
         Icon="/Assets/avalonia-logo.ico"
-        Title="OceanSimulation.Presentation.Avalonia">
-
+        Title="Ocean Simulation Test UI">
     <Design.DataContext>
-        <!-- This only sets the DataContext for the previewer in an IDE,
-             to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
         <vm:MainWindowViewModel/>
     </Design.DataContext>
-
-    <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-
+    <StackPanel Margin="10" Spacing="5">
+        <TextBlock Text="NetCDF File:"/>
+        <StackPanel Orientation="Horizontal" Spacing="5">
+            <TextBox Width="400" Text="{Binding NetcdfPath, UpdateSourceTrigger=PropertyChanged}"/>
+            <Button Content="Browse" Click="BrowseFile_Click"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Spacing="5" Margin="0,5">
+            <Button Content="Visualize" Command="{Binding VisualizeCommand}"/>
+            <Button Content="Vorticity/Divergence" Command="{Binding VorticityCommand}"/>
+            <Button Content="Particle Tracking" Command="{Binding ParticleCommand}"/>
+            <Button Content="Pollution" Command="{Binding PollutionCommand}"/>
+            <Button Content="EnKF" Command="{Binding EnkfCommand}"/>
+        </StackPanel>
+        <TextBlock Text="{Binding Status}" Margin="0,5"/>
+        <ScrollViewer Height="400">
+            <Image Source="{Binding ResultImage}" Stretch="Uniform"/>
+        </ScrollViewer>
+    </StackPanel>
 </Window>

--- a/Source/CSharpClient/OceanSimulation.Presentation.Avalonia/Views/MainWindow.axaml.cs
+++ b/Source/CSharpClient/OceanSimulation.Presentation.Avalonia/Views/MainWindow.axaml.cs
@@ -1,4 +1,8 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OceanSimulation.Presentation.Avalonia.ViewModels;
 
 namespace OceanSimulation.Presentation.Avalonia.Views;
 
@@ -7,5 +11,23 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+    }
+
+    private async void BrowseFile_Click(object? sender, RoutedEventArgs e)
+    {
+        var dialog = new OpenFileDialog
+        {
+            AllowMultiple = false,
+            Filters = new List<FileDialogFilter>
+            {
+                new FileDialogFilter { Name = "NetCDF", Extensions = { "nc" } }
+            }
+        };
+
+        var result = await dialog.ShowAsync(this);
+        if (result != null && result.Length > 0 && DataContext is MainWindowViewModel vm)
+        {
+            vm.NetcdfPath = result[0];
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add logging and project references to Avalonia app
- implement MainWindowViewModel with operations for visualization, vorticity/divergence and particle tracking
- update MainWindow layout and code-behind

## Testing
- `python --version`
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686769fc71f4832eb8de6397c512d2c4